### PR TITLE
Added default soft reset before entering the REPL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ You can use `mpbridge` in several ways based on your needs:
   You can specify your project directory as `DIR_PATH` and `mpbridge` will take care of changes when you are developing
   your project in your desired IDE. You can switch to `MicroPython REPL` anytime you wish to run the updated code on
   your board.
-
+* Automatic reset before entering MicroPython REPL can be enabled with `--auto-reset` option which can be set to
+  `soft` (soft reset) or `hard` (hard reset).
+  
 **Note** : `<PORT>` can be the **full port path** or one of the **short forms** below :
 
 * `c[n]` for `COM[n]` (`c3` is equal to `COM3`)

--- a/mpbridge/bridge.py
+++ b/mpbridge/bridge.py
@@ -75,6 +75,7 @@ def start_dev_mode(port: str, path: str, auto_hard_reset: bool):
             time.sleep(1)
         else:
             pyb.exit_raw_repl()
+            pyb.verbose_soft_reset()
             pyb.close()
         start_repl(port)
 

--- a/mpbridge/bridge.py
+++ b/mpbridge/bridge.py
@@ -51,7 +51,7 @@ def sync(port: str, path: str, clean: bool):
     pyb.exit_raw_repl_verbose()
 
 
-def start_dev_mode(port: str, path: str, auto_hard_reset: bool):
+def start_dev_mode(port: str, path: str, auto_reset: str):
     path = utils.replace_backslashes(path)
     port = utils.port_abbreviation(port)
     print(Fore.YELLOW, f"- Syncing files on {port} with {path}")
@@ -69,11 +69,14 @@ def start_dev_mode(port: str, path: str, auto_hard_reset: bool):
         input()
         push_deletes(pyb, path, old_ls=old_ls)
         pyb.sync_with_dir(dir_path=path)
-        if auto_hard_reset:
+        if auto_reset is None:
+            pyb.exit_raw_repl()
+            pyb.close()
+        elif auto_reset == "hard":
             pyb.verbose_hard_reset()
             pyb.close()
             time.sleep(1)
-        else:
+        elif auto_reset == "soft":
             pyb.exit_raw_repl()
             pyb.verbose_soft_reset()
             pyb.close()

--- a/mpbridge/pyboard.py
+++ b/mpbridge/pyboard.py
@@ -174,3 +174,7 @@ class SweetPyboard(Pyboard):
         self.serial.close()
         print(Fore.LIGHTGREEN_EX, "✓ Hard reset board successfully")
         utils.reset_term_color()
+
+    def verbose_soft_reset(self):
+        self.serial.write(b"\x04")
+        print(Fore.LIGHTGREEN_EX, "✓ Soft reset board successfully")

--- a/mpbridge/shell.py
+++ b/mpbridge/shell.py
@@ -51,8 +51,9 @@ def sync(port, dir_path, clean):
 @click.argument('port')
 @click.argument('dir_path', type=click.Path(
     exists=True, file_okay=False, dir_okay=True, resolve_path=True))
-@click.option('--reset', "-r", is_flag=True, help="Enable automatic hard reset")
-def dev(port, dir_path, reset):
+@click.option('--auto-reset',
+              type=click.Choice(['soft', 'hard'], case_sensitive=False))
+def dev(port, dir_path, auto_reset):
     """Start development mode on <PORT> in specified directory <DIR_PATH>
 
     <PORT> can be full path or :
@@ -63,4 +64,4 @@ def dev(port, dir_path, reset):
 
             c[n]  connect to serial port "COM[n]"
     """
-    bridge.start_dev_mode(port, dir_path, auto_hard_reset=reset)
+    bridge.start_dev_mode(port, dir_path, auto_reset=auto_reset)


### PR DESCRIPTION
A quick soft reset can get results immediately when we re-enter the REPL, especially if `main.py` exists.

