### PR TITLE
Implement --no-prompt flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ You can use `mpbridge` in several ways based on your needs:
 #### ⚜️ Development Mode
 
 * Run `mpbridge dev <PORT> <DIR_PARH>`
-* This mode repeats a loop of tasks in specified directory on `MicroPython` device as below :
-    * _Sync files_ → _Wait for changes (Develop your project)_ → _Sync files_ → _Start MicroPython REPL_
+* This mode repeats a loop of tasks in specified directory on `MicroPython` device as below:
+    * _Sync_ → _Prompt to enter REPL_ → _Clean Sync_ → _Start MicroPython REPL_
+* You can also disable prompt with`--no-prompt` option to speed things:
+    * _Clean Sync_ → _Start MicroPython REPL_
 * This mode is useful when you keep switching between different tools to flash and run new codes repeatedly.
   You can specify your project directory as `DIR_PATH` and `mpbridge` will take care of changes when you are developing
   your project in your desired IDE. You can switch to `MicroPython REPL` anytime you wish to run the updated code on

--- a/mpbridge/shell.py
+++ b/mpbridge/shell.py
@@ -51,9 +51,10 @@ def sync(port, dir_path, clean):
 @click.argument('port')
 @click.argument('dir_path', type=click.Path(
     exists=True, file_okay=False, dir_okay=True, resolve_path=True))
-@click.option('--auto-reset',
+@click.option('--auto-reset', help="Enables auto reset before entering REPL",
               type=click.Choice(['soft', 'hard'], case_sensitive=False))
-def dev(port, dir_path, auto_reset):
+@click.option('--no-prompt', is_flag=True, help="Disables prompt for entering REPL")
+def dev(port, dir_path, auto_reset, no_prompt: bool):
     """Start development mode on <PORT> in specified directory <DIR_PATH>
 
     <PORT> can be full path or :
@@ -64,7 +65,7 @@ def dev(port, dir_path, auto_reset):
 
             c[n]  connect to serial port "COM[n]"
     """
-    bridge.start_dev_mode(port, dir_path, auto_reset=auto_reset)
+    bridge.start_dev_mode(port, dir_path, auto_reset=auto_reset, no_prompt=no_prompt)
 
 
 @main.command("clear", short_help='Delete all files from MicroPython device')


### PR DESCRIPTION
This option disables prompt for entering REPL and reduces syncs to one time on each cycle.