### PR TITLE
Add --push-only flag to sync command

### DIFF
--- a/mpbridge/bridge.py
+++ b/mpbridge/bridge.py
@@ -40,16 +40,16 @@ def start_bridge_mode(port: str):
         observer.join()
 
 
-def sync(port: str, path: str, clean: bool, dry_run: bool):
+def sync(port: str, path: str, clean: bool, dry_run: bool, push_only: bool):
     port = utils.port_abbreviation(port)
     print(Fore.YELLOW, f"- Syncing files on {port} with {path}")
     utils.reset_term_color()
     pyb = SweetPyboard(device=port)
     pyb.enter_raw_repl_verbose()
     if clean:
-        print(Fore.YELLOW, "Clean Sync files")
+        print(Fore.YELLOW, f"Removing absent files from {port}")
         pyb.delete_absent_items(dir_path=path, dry=dry_run)
-    pyb.sync_with_dir(dir_path=path, dry=dry_run)
+    pyb.sync_with_dir(dir_path=path, dry=dry_run, push=push_only)
     pyb.exit_raw_repl_verbose()
 
 

--- a/mpbridge/pyboard.py
+++ b/mpbridge/pyboard.py
@@ -124,14 +124,14 @@ class SweetPyboard(Pyboard):
         print(Fore.LIGHTGREEN_EX, "✓ Copied all files successfully")
         utils.reset_term_color()
 
-    def sync_with_dir(self, dir_path, dry: bool = False):
+    def sync_with_dir(self, dir_path, dry: bool = False, push: bool = False):
         print(Fore.YELLOW, "- Syncing")
         self.exec_raw_no_follow(SHA1_FUNC)
         dir_path = utils.replace_backslashes(dir_path)
         rdirs, rfiles = self.fs_recursive_listdir()
         ldirs, lfiles = utils.recursive_list_dir(dir_path)
         ignore = IgnoreStorage(dir_path=dir_path)
-        if not dry:
+        if (not dry) and (not push):
             for rdir in rdirs.keys():
                 if rdir not in ldirs and not ignore.match_dir(rdir):
                     os.makedirs(dir_path + rdir, exist_ok=True)
@@ -145,11 +145,12 @@ class SweetPyboard(Pyboard):
                 if self.get_sha1(lfile_rel) == utils.get_file_sha1(lfiles_abs):
                     continue
             self.fs_verbose_put(lfiles_abs, lfile_rel, chunk_size=256, dry=dry)
-        for rfile, rsize in rfiles.items():
-            if ignore.match_file(rfile):
-                continue
-            if rfile not in lfiles:
-                self.fs_verbose_get(rfile, dir_path + rfile, chunk_size=256, dry=dry)
+        if not push:
+            for rfile, rsize in rfiles.items():
+                if ignore.match_file(rfile):
+                    continue
+                if rfile not in lfiles:
+                    self.fs_verbose_get(rfile, dir_path + rfile, chunk_size=256, dry=dry)
         print(Fore.LIGHTGREEN_EX, "✓ Files synced successfully")
 
     def delete_absent_items(self, dir_path, dry: bool = False):

--- a/mpbridge/shell.py
+++ b/mpbridge/shell.py
@@ -32,9 +32,13 @@ def bridge_mode(port):
 @click.argument('port')
 @click.argument('dir_path', type=click.Path(
     exists=True, file_okay=False, dir_okay=True, resolve_path=True), default="")
-@click.option('--clean', "-c", is_flag=True, help="Execute Clean Sync")
-@click.option('--dry-run', "-d", is_flag=True, help="Test Sync command without performing any actions")
-def sync(port, dir_path, clean, dry_run):
+@click.option('--clean', "-c", is_flag=True,
+              help="Execute Clean Sync")
+@click.option('--push-only', "-p", is_flag=True,
+              help="Only push changes without pulling anything from remote device")
+@click.option('--dry-run', "-d", is_flag=True,
+              help="Test Sync command without performing any actions")
+def sync(port, dir_path, clean, dry_run, push_only):
     """Sync files of on [PORT] in specified directory [DIR_PATH]
 
     If [DIR_PATH] is not set, it defaults to the current path
@@ -67,7 +71,7 @@ def sync(port, dir_path, clean, dry_run):
 
             and then push the different files from the local to the device.
     """
-    bridge.sync(port, dir_path, clean, dry_run)
+    bridge.sync(port, dir_path, clean, dry_run, push_only)
 
 
 @main.command("dev", short_help='Start development mode')


### PR DESCRIPTION
The `--push-only` flag disables **pulling** files and directories from remote device during `sync`.
Also solves #25 and can be useful while working with large projects on a single device.